### PR TITLE
Fixed the out of scope error for "ProgramResult"

### DIFF
--- a/programs/myepicproject/src/lib.rs
+++ b/programs/myepicproject/src/lib.rs
@@ -1,4 +1,6 @@
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::entrypoint::ProgramResult;
+
 
 declare_id!("ieiQKdin3gGPYTEbTBqANcgqynLNKjo4KgEdXEweqEW");
 


### PR DESCRIPTION
When we run "anchor test" command, we get the error "not found in this scope" i.e. error [E0412] of rust language docs. the error has been fixed by adding a declaration :)